### PR TITLE
chore: pin toolchain and plugin versions instead of latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ keywords:
   - giantswarm
 toolchain:
   repository: gsoci.azurecr.io/giantswarm/klaus-toolchains/go
-  tag: latest
+  tag: v0.1.2
 plugins:
   - repository: gsoci.azurecr.io/giantswarm/klaus-plugins/gs-base
-    tag: latest
+    tag: v0.1.0
   - repository: gsoci.azurecr.io/giantswarm/klaus-plugins/my-plugin
     tag: v1.0.0
 ```

--- a/personalities/sre/personality.yaml
+++ b/personalities/sre/personality.yaml
@@ -12,5 +12,5 @@ keywords:
   - platform
 toolchain:
   repository: gsoci.azurecr.io/giantswarm/klaus-toolchains/go
-  tag: latest
+  tag: v0.1.2
 plugins: []


### PR DESCRIPTION
## Summary

- Replace `tag: latest` with explicit pinned version tags in personality manifests and README example
- Toolchain `go`: `latest` → `v0.1.2`
- Plugin `base` (README example): `latest` → `v0.1.0`

## Why

Personality artifacts reference toolchain and plugin images via `tag: latest`, which gets resolved at publish time and then baked in. This means:

1. **Renovate cannot track updates** -- there is no explicit version to bump
2. **The SOUL.md injection fix (klaus v0.0.38)** shipped in the rebuilt toolchains (`go/v0.1.2`) but personalities still reference whatever `latest` resolved to at their last publish, missing the fix

Pinning explicit versions enables Renovate to open PRs when new toolchain or plugin versions are released, and ensures the current personalities pick up the rebuilt toolchains immediately.

## Changes

| File | Change |
|------|--------|
| `personalities/sre/personality.yaml` | Toolchain tag `latest` → `v0.1.2` |
| `README.md` | Example toolchain tag `latest` → `v0.1.2`, example plugin tag `latest` → `v0.1.0` |

## Self-review

Ran `base:code-reviewer` against the diff. Findings:

- **No `tag: latest` instances remain** in any personality YAML or README content
- Version tag formats are correct (semver with `v` prefix, matching release tags)
- README example is consistent with the actual personality manifest
- Out-of-scope finding noted: `actions/checkout@v6` in `auto-release.yaml` uses a floating tag instead of a pinned SHA (not addressed in this PR)

## Test plan

- [ ] Verify `personality.yaml` parses correctly with `klausctl personality validate` (CI)
- [ ] Confirm Renovate picks up the pinned versions for future tracking


🤖 Generated with [Claude Code](https://claude.com/claude-code)