### PR TITLE
feat: auto-update plugin and toolchain versions via Renovate and dispatch

### DIFF
--- a/.github/workflows/receive-dispatch.yaml
+++ b/.github/workflows/receive-dispatch.yaml
@@ -1,0 +1,132 @@
+---
+name: Receive upstream release dispatch
+
+on:
+  repository_dispatch:
+    types:
+      - plugin-release
+      - toolchain-release
+
+permissions: {}
+
+jobs:
+  update-version:
+    name: Update version reference
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Validate payload and determine parameters
+        id: params
+        env:
+          EVENT_TYPE: ${{ github.event.action }}
+          COMPONENT: ${{ github.event.client_payload.component }}
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${COMPONENT}" ] || [ -z "${VERSION}" ]; then
+            echo "::error::Missing required client_payload fields: component and version"
+            exit 1
+          fi
+
+          # Validate component name contains only safe characters
+          COMPONENT_RE='^[a-zA-Z0-9][a-zA-Z0-9/_.-]+$'
+          if ! [[ "${COMPONENT}" =~ ${COMPONENT_RE} ]]; then
+            echo "::error::Component '${COMPONENT}' contains invalid characters"
+            exit 1
+          fi
+
+          # Validate version matches semver (with optional v prefix)
+          SEMVER_RE='^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if ! [[ "${VERSION}" =~ ${SEMVER_RE} ]]; then
+            echo "::error::Version '${VERSION}' does not match semver pattern"
+            exit 1
+          fi
+
+          echo "Received ${EVENT_TYPE}: component=${COMPONENT} version=${VERSION}"
+
+          BRANCH="chore/update-${COMPONENT//\//-}-${VERSION}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "component=${COMPONENT}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "event_type=${EVENT_TYPE}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Update personality manifests
+        id: update
+        env:
+          EVENT_TYPE: ${{ steps.params.outputs.event_type }}
+          COMPONENT: ${{ steps.params.outputs.component }}
+          VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          updated=0
+
+          for manifest in personalities/*/personality.yaml; do
+            if [ "${EVENT_TYPE}" = "toolchain-release" ]; then
+              # Match only indented toolchain repository lines (not top-level metadata)
+              if grep -Fq "  repository:" "$manifest" && grep -F "  repository:" "$manifest" | grep -Fq "${COMPONENT}"; then
+                sed -i "\|repository:.*${COMPONENT}|{ n; s/tag:.*/tag: ${VERSION}/ }" "$manifest"
+                echo "Updated toolchain in ${manifest}"
+                updated=1
+              fi
+            elif [ "${EVENT_TYPE}" = "plugin-release" ]; then
+              # Match only indented plugin repository lines
+              if grep -Fq "  repository:" "$manifest" && grep -F "  repository:" "$manifest" | grep -Fq "${COMPONENT}"; then
+                sed -i "\|repository:.*${COMPONENT}|{ n; s/tag:.*/tag: ${VERSION}/ }" "$manifest"
+                echo "Updated plugin in ${manifest}"
+                updated=1
+              fi
+            fi
+          done
+
+          if [ "${updated}" -eq 0 ]; then
+            echo "No manifests reference component '${COMPONENT}', nothing to update"
+          fi
+
+          echo "updated=${updated}" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        if: steps.update.outputs.updated == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.params.outputs.branch }}
+          COMPONENT: ${{ steps.params.outputs.component }}
+          VERSION: ${{ steps.params.outputs.version }}
+          EVENT_TYPE: ${{ steps.params.outputs.event_type }}
+        run: |
+          set -euo pipefail
+
+          # Check if any files were modified
+          if git diff --quiet; then
+            echo "No changes detected, skipping PR creation"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "${BRANCH}"
+          git add personalities/
+          git commit -m "chore: update ${COMPONENT} to ${VERSION}"
+          git push origin "${BRANCH}"
+
+          KIND="plugin"
+          if [ "${EVENT_TYPE}" = "toolchain-release" ]; then
+            KIND="toolchain"
+          fi
+
+          gh pr create \
+            --title "chore: update ${KIND} ${COMPONENT} to ${VERSION}" \
+            --body "Automated version bump triggered by upstream ${KIND} release dispatch.
+
+          **Component:** \`${COMPONENT}\`
+          **Version:** \`${VERSION}\`
+          **Trigger:** \`${EVENT_TYPE}\`" \
+            --base main

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,5 +15,40 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$",
     },
+    // Detect toolchain OCI image references in personality manifests.
+    // Matches YAML like:
+    //   toolchain:
+    //     repository: gsoci.azurecr.io/giantswarm/klaus-toolchains/go
+    //     tag: v0.1.2
+    {
+      "customType": "regex",
+      "fileMatch": ["^personalities/.+/personality\\.yaml$"],
+      "matchStrings": [
+        "toolchain:\\s*\\n\\s+repository:\\s*(?<registryUrl>[^/]+)/(?<depName>[^\\s]+)\\s*\\n\\s+tag:\\s*(?<currentValue>v?\\S+)",
+      ],
+      "datasourceTemplate": "docker",
+    },
+    // Detect plugin OCI image references in personality manifests.
+    // Matches YAML like:
+    //   plugins:
+    //     - repository: gsoci.azurecr.io/giantswarm/klaus-plugins/foo
+    //       tag: v1.0.0
+    {
+      "customType": "regex",
+      "fileMatch": ["^personalities/.+/personality\\.yaml$"],
+      "matchStrings": [
+        "-\\s+repository:\\s*(?<registryUrl>[^/]+)/(?<depName>[^\\s]+)\\s*\\n\\s+tag:\\s*(?<currentValue>v?\\S+)",
+      ],
+      "datasourceTemplate": "docker",
+    },
+  ],
+  "packageRules": [
+    // Automerge minor and patch updates for toolchains and plugins
+    {
+      "matchFileNames": ["personalities/*/personality.yaml"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Added custom Renovate regex managers to detect toolchain and plugin OCI image version references in personality manifests (`personality.yaml` files)
- Configured Renovate automerge for minor/patch version bumps on personality manifests
- Added a `repository_dispatch` receiver workflow (`receive-dispatch.yaml`) that handles `plugin-release` and `toolchain-release` events from upstream repos (`klaus-plugins`, `klaus-toolchains`), validates the incoming version via semver regex, updates the relevant personality YAML files, and opens a PR

## Changes

### `renovate.json5`
- New regex manager for toolchain OCI references (`toolchain.repository` + `toolchain.tag`)
- New regex manager for plugin OCI references (list entries under `plugins:`)
- Package rule enabling automerge for minor/patch updates on personality manifests

### `.github/workflows/receive-dispatch.yaml` (new)
- Listens for `plugin-release` and `toolchain-release` repository dispatch events
- Validates `component` (allowlist regex) and `version` (semver) from `client_payload`
- Updates matching `tag:` fields in personality manifests using `sed` with alternate delimiters
- Creates a PR with the version bump

## Security considerations

- All `client_payload` values are passed through `env:` mappings (no inline expression injection)
- `COMPONENT` is validated against `^[a-zA-Z0-9][a-zA-Z0-9/_.-]+$` to prevent regex/sed injection
- `VERSION` is validated against strict semver before use
- `actions/checkout` is pinned to commit SHA (`de0fac2e...`)
- Permissions scoped to job level with `permissions: {}` at workflow level
- `grep -F` used for fixed-string matching (no regex interpretation of user input)
- `sed` uses `\|...|` alternate delimiters to handle `/` in component paths

## Self-review summary

**Code reviewer** found and we fixed: sed delimiter collision with `/` in component paths, grep matching top-level `repository:` metadata, duplicate if/elif branches (kept for clarity/future divergence), unpinned checkout action.

**Security auditor** found and we fixed: missing COMPONENT validation (injection risk), split validation/usage steps (merged), unpinned actions (pinned to SHA), workflow-level write permissions (scoped to job).

## Test plan

- [ ] Verify Renovate dry-run detects the toolchain reference in `personalities/sre/personality.yaml`
- [ ] Verify dispatch workflow validates and rejects invalid semver / component names
- [ ] Verify dispatch workflow correctly updates `tag:` in personality manifests
- [ ] Verify automerge config applies only to personality manifest minor/patch updates

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)