### PR TITLE
fix: use cimg/base:stable in CircleCI setup config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   generate-config:
     docker:
-      - image: cimg/base:current
+      - image: cimg/base:stable
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Summary

- Switch Docker image in `.circleci/config.yml` from `cimg/base:current` to `cimg/base:stable` for consistency and stability across artifact repos.

Closes #4
Part of giantswarm/giantswarm#35994

## Self-review

Reviewed by `base:code-reviewer` and `code-quality:security-auditor` before submission.

- **Code review**: No issues. Change is correct and minimal.
- **Security audit**: No critical or high findings. One medium note about floating Docker tags (pre-existing, applies to both `current` and `stable`). Two low findings for items explicitly out of scope (orb version managed by Renovate; `generate-config.sh` noop function is a separate concern).

## Test plan

- [ ] CI pipeline passes — `generate-config.sh` runs successfully on `cimg/base:stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)