### PR TITLE
fix: correct sre toolchain tag to match OCI registry

### DIFF
--- a/personalities/sre/personality.yaml
+++ b/personalities/sre/personality.yaml
@@ -12,5 +12,5 @@ keywords:
   - platform
 toolchain:
   repository: gsoci.azurecr.io/giantswarm/klaus-toolchains/go
-  tag: v0.1.2
+  tag: 0.1.3
 plugins: []


### PR DESCRIPTION
## Summary

- The sre personality referenced `gsoci.azurecr.io/giantswarm/klaus-toolchains/go:v0.1.2`, but OCI registry tags don't use the `v` prefix.
- Updated to `0.1.3` (the current version in the registry).

Made with [Cursor](https://cursor.com)